### PR TITLE
Mentioning release 1.0.6

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,14 @@ owner: Security Engineering
 
 This topic contains release notes for the Pivotal Cloud Foundry (PCF) ClamAV add-on.
 
+##v1.0.6
+
+PCF Clam-AV add-on v1.0.0 bundles the clamav-0.99.2 distribution from 2016-10-03 containing fixes for the following CVEs:
+
+* [CVE-2016-1371](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1371)
+* [CVE-2016-1372](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1372)
+* [CVE-2016-1405](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1405)
+
 ##v1.0.0
 
 PCF Clam-AV add-on v1.0.0 bundles the clamav-0.99.2 distribution.


### PR DESCRIPTION
[#131756841] ClamAV release notes should mention release 1.0.6

Signed-off-by: Slawek Ligus <sligus@pivotal.io>