### PR TITLE
Add log format note, remove ramblings.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -13,8 +13,6 @@ This add-on may be necessary for regulatory purposes if your compliance auditor 
 For example, auditors sometimes expect that antivirus protection be present in an environment that must comply with standards such as 
 Payment Card Industry Data Security Standard (PCI DSS) or Health Insurance Portability and Accountability Act (HIPAA).
 
-ClamAV can be configured to scan on-access or on schedule, but not both.
-
 ##<a id="prereqs"></a>Prerequisites
 
 <p class="note"><strong>Note</strong>: ClamAV Add-on for PCF does not work on Windows.</p>
@@ -28,7 +26,7 @@ For more information, see [Understanding Pivotal Cloud Foundry User Types](https
 
 * ClamAV Add-on uses 610&nbsp;MB of memory. Ensure you have at least 1&nbsp;GB of memory free on each VM before deploying ClamAV Add-on.
 
-* For performance reasons, you must set up a local mirror to get ClamAV virus updates.
+* You must set up a local mirror to get ClamAV virus updates.
 For instructions on how to set up a local mirror, see [Private Local Mirrors](https://www.clamav.net/documents/private-local-mirrors) in the ClamAV documentation.
 
 ##<a id="create-mfest"></a>Create the ClamAV Manifest
@@ -50,13 +48,12 @@ Follow the steps below to create the ClamAV manifest for your deployment:
           database\_mirror: <%= vars.example_ip_1 %>
 </pre>
 
-2. (Required) Provide the hostname or IP address of a private ClamAV update mirror. This is necessary for performance reasons. 
-Environments that cannot connect to the Internet normally use an update mirror. 
-If you do not specify a value, ClamAV defaults to `db.local.clamav.net` for updates. Mirror servers behind this address might be unreachable which may lead to a failed ClamAV Add-on deployment.
+2. (Required) Provide the hostname or IP address of a private ClamAV update mirror. Environments that cannot connect to the Internet normally use an update mirror. 
+If you do not specify a value, ClamAV defaults to an S3-based mirror for updates. For compliance reasons, the S3-based mirror should only be used in non-prod environments.
 For instructions on how to set up a local mirror, see [Private Local Mirrors](https://www.clamav.net/documents/private-local-mirrors) in the ClamAV documentation.
 See the [Private Local Mirrors](https://www.clamav.net/documents/private-local-mirrors) topic of the ClamAV documentation for instructions on how to set up a local mirror.
 
-3. (Optional) If you have to use a proxy server to connect to the internet, do the following:
+3. (Optional) If you have to use a proxy server to connect to the Internet, do the following:
     + Add the `proxy_host` and `proxy_port` properties.
     + If the proxy server needs authentication, add `proxy_user` and `proxy_password` properties.
 
@@ -81,7 +78,7 @@ See the [Private Local Mirrors](https://www.clamav.net/documents/private-local-m
   ...
   </pre>
 
-##<a id="download-deploy"></a>Download and Deploy ClamAV Add-on  
+##<a id="download-deploy"></a>Download and Deploy ClamAV Add-on
 
 1. Download ClamAV Add-on software binary from the [Pivotal Network](https://network.pivotal.io/products/p-clamav-addon) to your local machine.
 
@@ -177,11 +174,22 @@ Pivotal recommends forwarding logs to a remote syslog aggregation system. </p>
     X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
     ```
 
-    This is a virus signature used to test anti-virus software. 
-    It may take up to an hour for ClamAV to locate the signature. 
-    Check your syslog aggregator for the notification. 
-    If the notification does not appear, check `/var/log/messages` on the VM. 
-    If virus notifications appear in the VM syslog but not in the aggregator, verify your syslog forwarding settings.
+    This is a virus signature used to test anti-virus software. Once `clamdscan` completes successfully a notification should appear in `/var/log/messages`.
+
+###<a id="format"></a>Clamav Log Format
+
+ClamAV log format is unstructured. On virus detection, the following text will be sent to syslog:
+
+```
+Jul 11 17:36:35 k2lam76scmb clamd[3022]: SelfCheck: Database status OK.
+Jul 11 17:42:34 k2lam76scmb clamd[3022]: /bin/infected-file: Eicar-Test-Signature FOUND
+```
+
+The logline can be generalized as follows:
+
+```
+clamd[PID]: <infected-file-path>: <virus name> FOUND
+```
 
 ##<a id="setup-on-access"></a>Enable On-Access Scan
 


### PR DESCRIPTION
We now support both on-access and scheduled scan.

[#142802831] Add sample syslog entries for ClamAV