### PR TITLE
Bump ClamAV to version 0.99.3 for CVE fixes

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -13,7 +13,7 @@ This topic contains release notes for ClamAV Add-on for PCF v1.3.
 This release of ClamAV Add-on for PCF:
 
 * Includes an updated open source license disclosure file.
-* Acceptance tests for Windows have been updated for bosh2.
+* Acceptance tests for Windows have been updated for the BOSH CLI v2.
 
 ## v1.3.11 (GA)
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -5,7 +5,17 @@ owner: Security Engineering
 
 <strong><%= modified_date %></strong>
 
-This topic contains release notes for ClamAV Add-on for PCF v1.3.
+This topic contains release notes for ClamAV Add-on for PCF:
+## v1.4.1 (GA)
+
+**Release Date:** February 5, 2018
+
+This release of ClamAV Add-on for PCF:
+
+* Upgrades the bundled ClamAV open source distribution to version 0.99.3, which includes
+  fixes for CVE-2017-12374, CVE-2017-12375, CVE-2017-12376, CVE-2017-12377, CVE-2017-12378,
+  CVE-2017-12379, and CVE-2017-12380.
+
 ## v1.3.28 (GA)
 
 **Release Date:** January 24, 2018


### PR DESCRIPTION
This PR updates the release notes to reflect the bump in ClamAV version, which fixes 6 CVEs.

The new ClamAV release is 1.4.1 . Not sure of the best way to maintain the two branches, but I made these changes against the head of the 1.3 branch, since that was the latest.