### PR TITLE
V1.4.5 update

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,15 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
+## v1.4.2 (GA)
+
+**Release Date:** March 26, 2018
+
+This release of ClamAV Add-on for PCF:
+
+* Upgrade the bundled ClamAV open source distribution to v0.99.4, which include fixes for CVE-2012-6706, CVE-2017-6419, CVE-2017-11423, CVE-2018-1000085, CVE-2018-0202 and GCC 6, C++11 compatibility issues.
+* Bumped Golang linux dependency to 1.10.
+
 ## v1.4.1 (GA)
 
 **Release Date:** February 5, 2018

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,7 +7,7 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
-## v1.4.2 (GA)
+## v1.4.5 (GA)
 
 **Release Date:** March 26, 2018
 


### PR DESCRIPTION
The latest build is v1.4.5, so changing the release notes to match that version. This is a jump from 1.4.1.