### PR TITLE
1.4.29

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -22,23 +22,23 @@ The following table provides version and version-support information about the C
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.4.28</td>
+        <td>v1.4.29</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 28, 2018</td>
+        <td>July 30, 2018</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.7 or later</td>
+        <td>v1.12 or later</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.7 or later</td>
+        <td>v1.12 or later</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS)<sup>*</sup> version(s)</td>
-        <td>v1.7 or later</td>
+        <td>v1.12 or later</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,8 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
+## v1.4.29 GA
+
 **Release Date:** July 30, 2018
 
 ### Features
@@ -24,7 +26,7 @@ This topic contains release notes for ClamAV Add-on for PCF.
 
 There are no known issues for this release.
 
-## v1.4.29 GA
+## v1.4.28 GA
 
 **Release Date:** June 28, 2018
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -17,9 +17,8 @@ This topic contains release notes for ClamAV Add-on for PCF.
         <li>CVE-2017-16932</li>
         <li>CVE-2018-0360</li>
         <li>CVE-2018-0361</li>
-        <li>Full ClamAV v0.100.1 release notes available [here](https://blog.clamav.net/2018/07/clamav-01001-has-been-released.html).</li>
 </ul>
-
+* Full ClamAV v0.100.1 release notes available [here](https://blog.clamav.net/2018/07/clamav-01001-has-been-released.html).
 
 ### Known Issues
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,7 +7,25 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
-## v1.4.28 GA
+**Release Date:** July 30, 2018
+
+### Features
+
+* Upgrades the bundled ClamAV open source distribution to v0.100.1, which includes:<br><br>
+**Security fixes**
+<ul>
+        <li>CVE-2017-16932</li>
+        <li>CVE-2018-0360</li>
+        <li>CVE-2018-0361</li>
+        <li>Full ClamAV v0.100.1 release notes available [here](https://blog.clamav.net/2018/07/clamav-01001-has-been-released.html).</li>
+</ul>
+
+
+### Known Issues
+
+There are no known issues for this release.
+
+## v1.4.29 GA
 
 **Release Date:** June 28, 2018
 


### PR DESCRIPTION
v1.4.29 now has a PCF v1.12+ requirement. This is a soft requirement and allows us to limit the support of ClamAV to 4 PCF versions. Note that the previous version, 1.4.28, support PCF v1.7+. I feel the docs outline what to do for each version quite well and do not require further changes.