### PR TITLE
Updated index and release notes for build 1.4.34.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -22,11 +22,11 @@ The following table provides version and version-support information about the C
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.4.29</td>
+        <td>v1.4.34</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>July 30, 2018</td>
+        <td>September 4, 2018</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>
@@ -34,7 +34,7 @@ The following table provides version and version-support information about the C
     </tr>
     <tr>
         <td>Compatible Elastic Runtime versions</td>
-        <td>v1.12 </td>
+        <td>v1.12 or later</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS)<sup>*</sup> versions</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,20 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
+## v1.4.34 GA
+
+**Release Date:** September 4, 2018
+
+### Features
+
+New features in this release:
+
+* Added the ability to schedule scan start time for daily scans.
+
+### Known Issues
+
+There are no known issues for this release.
+
 ## v1.4.29 GA
 
 **Release Date:** July 30, 2018


### PR DESCRIPTION
Will have to cherry-pick the release notes back to master, not sure about the index page.
Would like this to be in staging along with the commit (to master branch) of updating the installation steps for schedule scan times.
Targeting Sept 4th for release, the dates reflect that.