### PR TITLE
Added Action Destination Warning

### DIFF
--- a/install.html.md.erb
+++ b/install.html.md.erb
@@ -447,6 +447,11 @@ If you don't supply an action, the function fails.
     The system does not scan the moved-to or copied-to location.
     If the directory path is not valid, the function fails.<br/>
     <br>
+
+    <p class="note warning"><strong>WARNING</strong>:
+    If `action` is `move` or `copy`, ensure the `action_destination` path is also added to the `exclude_paths`.
+    If the `action_destination` is not listed under `exclude_paths` clamav will detect the moved/copied file, ClamAV will log redundant alerts and create additional copies of the detected file.
+    </p>
     Example configuration:
 
 <pre><code>releases:
@@ -461,6 +466,11 @@ addons:
         clamav:
           action: move
           action_destination: /var/vcap/data/clamav/found
+          exclude_paths:
+          - ^/sys
+          - ^/proc
+          - ^/var/vcap/data/clamav/found
+
 ...</code></pre>
   </li>
 </ol>

--- a/install.html.md.erb
+++ b/install.html.md.erb
@@ -467,9 +467,9 @@ addons:
           action: move
           action_destination: /var/vcap/data/clamav/found
           exclude_paths:
-          - ^/sys
-          - ^/proc
-          - ^/var/vcap/data/clamav/found
+          - ^/proc/
+          - ^/sys/
+          - ^/var/vcap/data/clamav/found/
 
 ...</code></pre>
   </li>


### PR DESCRIPTION
If action is move or copy, the action_destination field should also be added to the exclude_paths list