### PR TITLE
Add troubleshooting section for failing deployments due to insufficient cpu

### DIFF
--- a/install.html.md.erb
+++ b/install.html.md.erb
@@ -90,17 +90,17 @@ To use these properties, place the following text under the `clamav` subsection 
         <li>This property is <code>false</code> by default.</li>
     </ul>
 
-    <code><strong>memory\_limit</strong></code>: <a name="memory_limit"></a>
-    <ul>
-      <li>Limits the maximum amount of user memory (including file cache) in bytes used by ClamAV.</li>
-      <li>The default value is <code>1073741824</code>.</li>
-    </ul>
-
     <p class="note warning"><strong>WARNING</strong>:
       If <code>enforce_cpu_limit</code> is set <code>true</code>, ensure <code>cpu_limit</code>
       is set high enough for ClamAV to execute normally.
       If the limit is too strict, ClamAV fails to start.
       For example, an n1-standard VM on GCP requires <code>cpu_limit</code> to be > 45.</p>
+
+    <code><strong>memory\_limit</strong></code>: <a name="memory_limit"></a>
+    <ul>
+      <li>Limits the maximum amount of user memory (including file cache) in bytes used by ClamAV.</li>
+      <li>The default value is <code>1073741824</code>.</li>
+    </ul>
 
 ### <a id="windows-template"></a>clamav.yml Template for Windows
 

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -106,3 +106,33 @@ For more information, see [clamav.yml Template for Linux](./install.html#linux-t
 
 <p class="note warning"><strong>Warning:</strong> When updating the memory limit, ensure that all VMs,
 including errand VMs, have sufficient memory resources.</p>
+
+### <a id='insufficient-cpu'></a> Insufficient CPU Limit While Using ClamAV
+
+#### Symptom
+ClamAV fails to start during deployment, however the process succeeds in running eventually. An example of the deployment failure log is:
+
+<pre class="terminal">
+Task 1071 | 19:40:49 | Updating instance clamav_1: clamav_1/d5cfe4bd-b606-4372-8481-187f4cf57e6c (0) (canary) (00:05:26)
+                L Error: 'clamav_1/d5cfe4bd-b606-4372-8481-187f4cf57e6c (0)' is not running after update. Review logs for failed jobs: clamd, freshclam
+</pre>
+
+The following command shows monit processes on the deployment: `bosh -d DEPLOYMENT instances --ps`. The result shows that the `clamd` and `freshclam` processes are successfully running after the failed deployment.
+
+<pre class="terminal">
+Instance                                       Process    Process State  AZ  IPs
+clamav_1/d5cfe4bd-b606-4372-8481-187f4cf57e6c  -          running        z1  10.0.0.7
+~                                              clamd      running        -   -
+~                                              freshclam  running        -   -
+</pre>
+
+####Explanation
+ClamAV startup is CPU intensive and if restricted, can prevent ClamAV from starting up correctly.
+
+#### Solutions
+1) Ensure `cpu_limit` is set high enough for ClamAV to execute normally. If the limit is too strict, ClamAV fails to start.
+For example, an n1-standard VM on GCP requires `cpu_limit` to be > 45.
+
+2) Disable `enforce_cpu_limit` so that more CPU cycles are allocated to ClamAV if other processes are not using CPU resources.
+
+3) Update the machine type of failing VMs with ClamAV to have sufficient CPU resources.


### PR DESCRIPTION
Also move the installation warning to immediately follow the enforce_cpu_limit section.