### PR TITLE
v1.4.45 release notes - unzip bomb fox [#167737172]

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -25,11 +25,11 @@ The following table provides version and version-support information about the C
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>1.4.39</td>
+        <td>1.4.45</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 10, 2018</td>
+        <td>August 26, 2018</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,24 @@ owner: Security Engineering
 
 This topic contains release notes for ClamAV Add-on for PCF.
 
+## v1.4.45
+
+**Release Date:** August 26, 2019
+
+### Features
+
+Changes in this release:
+
+* The bundled ClamAV open source distribution is now v0.101.3.
+  This new version of ClamAV includes the following security fixes:
+
+    + [Non-recursive Zip Bombs](https://blog.clamav.net/2019/08/clamav-01013-security-patch-release-and.html):
+    A Denial-of-Service (DoS) vulnerability may occur when scanning a zip bomb as a result of excessively long scan times.
+
+### Known Issues
+
+There are no known issues for this release.
+
 ## v1.4.39
 
 **Release Date:** December 10, 2018


### PR DESCRIPTION
Hi Services Docs team.

ClamAV discovered a "somewhat" major CVE that exists in all our versions of ClamAV to date. This update address it, in the older (non-tile) format of ClamAV. Getting customers to do a major upgrade of our product just to address a CVE doesn't feel very nice to me...

The ClamAV tile that we were going to GA with is getting an update and the updated version (going through OSL now) will have the same fix. The updated version from the GA version is just a ClamAV bump. This raises the issue where, in the docs, we normally just provide the highlights of 1 ClamAV version bump. The ClamAV update notes that Chris wrote for 101.2 still applies, as 101.3 only address the unzip bomb issue. Just wanted to call this out for you so you can best tackle it.

In the non-tile version, The last version of ClamAV that is in the release notes is 0.100.2. So we are jumping to 101.3, which needs to be handled as well (maybe we just don't include the release notes of the intermediate version).