### PR TITLE
[#169353113] set log destination to antivirus.stdout.log instead of c…

### DIFF
--- a/monitoring-logs.html.md.erb
+++ b/monitoring-logs.html.md.erb
@@ -59,7 +59,7 @@ The clamd job uses the database of virus signatures that the freshclam job updat
 The messages output by the clamd app show files where viruses are found, the name of the  virus signature,
 and any action taken (such as moving, copying, or deleting).
 
-The log file for the clamd app is `/var/vcap/sys/log/antivirus/clamd.log`.
+The log file for the clamd app is `/var/vcap/sys/log/antivirus/antivirus.stdout.log`.
 
 ###<a id="clamdscan-app"></a> clamdscan App
 


### PR DESCRIPTION
…lamd.log

Signed-off-by: Carl He <jhe@pivotal.io>