### PR TITLE
Release notes 2.2.13

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,6 +8,17 @@ This topic contains release notes for <%= vars.product_full %>.
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
+## <a id="2-2-13"></a> v2.2.13
+**Release Date: January 21, 2021**
+
+### Features
+New features and changes in this release:
+* Updates golang dependency to v1.15 for both Linux and Windows
+
+### Known Issues
+There are no known issues in this release.
+
+
 ## <a id="2-2-8"></a> v2.2.8
 **Release Date: June 19, 2020**
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
No.

This is the final release from the PCI team for Antivirus Tile before transitioning Antivirus Tile to the Cryogenics team. 
We have removes all reference to 3.0 from Github and TanzuNet as a part of this transition. Can you please delete tho 3.0 branch from this repo as well.
