### PR TITLE
add default VM size note for antivirus mirror

### DIFF
--- a/install-mirror.html.md.erb
+++ b/install-mirror.html.md.erb
@@ -36,6 +36,7 @@ For compatible versions, see the [Product Snapshot](./index.html#snapshot).
 This is so that you can install the <%= vars.product_full %> tile after deploying this mirror.
 <%= vars.product_short %> installs itself on each tile VM and runs internally.
 <%= vars.product_short %> takes at least 610&nbsp;MB of RAM on each VM.
+On Google Cloud Platform (GCP), the recommended minimum VM size is `micro.cpu` using 2&nbsp;CPU and 2&nbsp;GB RAM.
 
 ## <a id='install-mirror'></a> Install <%= vars.product_full_mirror %>
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -14,6 +14,7 @@ This topic contains release notes for <%= vars.product_full %>.
 ### Features
 New features and changes in this release:
 * Updates golang dependency to v1.15 for both Linux and Windows
+* Default VM size for Antivirus Mirror set to 2&nbsp;CPU and 2&nbsp;GB RAM to avoid startup error caused by resource contention.
 
 ### Known Issues
 There are no known issues in this release.


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
All supported branches