### PR TITLE
Remove unsupported mirror from solution

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -60,9 +60,7 @@ The <%= vars.product_full_mirror %> server was unavailable during initial deploy
 #### Solution
 
 Review the manifest file, and replace the `database_mirror` key with the address
-of a stable mirror server.
-If you do not have a stable mirror server for reliable initial deployment,
-use the S3-based mirror: `pivotal-anti-virus-mirror.s3.amazonaws.com`
+of a stable mirror server. The official supported mirror is: database.clamav.net.
 
 ### <a id="antivirus-fails-to-start"></a> <%= vars.ops_manager %> Antivirus Job Fails To Start
 


### PR DESCRIPTION
Hi Docs team!

We discovered today that there was a non-supported mirror being suggested as a solution. We have now removed that reference in the docs, and listed the official mirror instead. 

Many thanks

James
