### PR TITLE
Add release notes for 2.3.2

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,6 +8,21 @@ This topic contains release notes for <%= vars.product_full %>.
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
+## <a id="2-3-2"></a> v2.3.2
+
+**Release Date: July 13, 2021**
+
+### Maintenance Changes
+
+Changes in this release:
+
+* **Clamav release:** Updated to v0.103.3
+* On access scanning now run as a separate process: `clamonacc`
+
+### Known issues
+
+There are no known issues for this release.
+
 ## <a id="2-2-19"></a> v2.2.19
 
 **Release Date: April 30, 2021**


### PR DESCRIPTION
Hi Docs team!

We're ready to release Antivirus 2.3.2, here are the release notes. 

If you could merge and confirm, we will then release on TanzuNet. 

Thanks

James

CC @kirederik 
