### PR TITLE
Amend upgrade info 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ As of April 16, 2020:
 
 | Branch name… | Documents version… | Publishes to… |
 |-------------|----------------|----------------|
-| master   | 3.0 (unreleased)     | https://docs-pcf-staging.cfapps.io/addon-antivirus/3-n/index.html |
+| master   | 2.4 (unreleased)     | https://docs-pcf-staging.cfapps.io/addon-antivirus/3-n/index.html |
+| 2.3   | 2.3.x     | https://docs.pivotal.io/addon-antivirus/2-3/index.html and https://docs-pcf-staging.cfapps.io/addon-antivirus/2-3/index.html |
 | 2.2   | 2.2.x     | https://docs.pivotal.io/addon-antivirus/2-2/index.html and https://docs-pcf-staging.cfapps.io/addon-antivirus/2-2/index.html |
 | 2.1   | 2.1.x    | https://docs.pivotal.io/addon-antivirus/2-1/index.html and https://docs-pcf-staging.cfapps.io/addon-antivirus/2-1/index.html |
 | 2.0   | 2.0.x     | https://docs.pivotal.io/addon-antivirus/2-0/index.html and https://docs-pcf-staging.cfapps.io/addon-antivirus/2-0/index.html |

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -138,10 +138,10 @@ and serves them to the `freshclam` processes of BOSH VMs.
 
 1. On each BOSH-managed VM:
 
-    1. The `freshclam` daemon process regularly queries the internal <%= vars.product_short_mirror %> for new virus definitions.
+    1. The `go-clam-tls` daemon process regularly queries the internal <%= vars.product_short_mirror %> for new virus definitions.
       - You can configure the query frequency in the <%= vars.product_full %> tile > **ClamAV Configuration** > **Number of database checks per day** field.
 
-    1. When `freshclam` retrieves new definitions, it:
+    1. When `go-clam-tls` retrieves new definitions, it:
       - Notifies the `clamd` daemon process that there are new definitions, and
       - Saves the virus definitions in the BOSH VM's own virus database.
 
@@ -159,10 +159,11 @@ This diagram illustrates how virus definitions propagate to BOSH VMs with <%= va
 [//]: https://docs.google.com/presentation/d/1pBHK0dcE5y7rT4KnacqFDc6LuU8R3HiR9ApuvwY1uzA/edit
 ![Online (non-air-gapped) update process, following path of new virus data.
 External ClamAV database in the cloud serves new virus data to freshclam running
-on local Anti-Virus Mirror.
-The local mirror runs it through the database verifier, also on Anti-Virus Mirror
-and then serves it to go-clam-tls on all BOSH VMs.
-On each BOSH VM, go-clam-tls notifies clamd that there are new definitions,
+on Anti-Virus Mirror VM in the TAS for VMs.
+The Anti-Virus Mirror VM in the TAS for VMs deployment runs it through the database verifier,
+which is also on the Anti-Virus Mirror VM,
+and then using mTLS serves it to go-clam-tls on all BOSH VMs.
+On each BOSH VM that is running Anti-Virus for VMware Tanzu, go-clam-tls notifies clamd that there are new definitions,
 and saves the definitions in the virus database.
 clamd then loads the new virus definitions from the database into its memory to
 enable fast scanning.](update-defs-online.jpg)
@@ -173,11 +174,13 @@ This diagram illustrates how virus definitions propagate to BOSH VMs with <%= va
 
 [//]: https://docs.google.com/presentation/d/1pBHK0dcE5y7rT4KnacqFDc6LuU8R3HiR9ApuvwY1uzA/edit
 ![Air-gapped update process, following path of new virus data.
-Operator downloads virus data from External ClamAV database in the cloud,
-then runs BOSH SCP to send it to freshclam running on local Anti-Virus Mirror.
-The local mirror runs it through the database verifier, also on Anti-Virus Mirror,
-and then serves it to go-clam-tls on all BOSH VMs.
-On each BOSH VM, go-clam-tls notifies clamd that there are new definitions,
+Operators download virus data from External ClamAV database in the cloud to an online workstation.
+They transfer the virus data to the air-gapped off-line workstation.
+The operators then run BOSH SCP to send the data to freshclam running on Anti-Virus Mirror VM in the TAS for VMs.
+The Anti-Virus Mirror VM in the TAS for VMs deployment runs it through the database verifier,
+which is also on the Anti-Virus Mirror VM,
+and then using mTLS serves it to go-clam-tls on all BOSH VMs.
+On each BOSH VM that is running Anti-Virus for VMware Tanzu, go-clam-tls notifies clamd that there are new definitions,
 and saves the definitions in the virus database.
 clamd then loads the new virus definitions from the database into its memory to
 enable fast scanning.](update-defs-airgap.jpg)

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -27,11 +27,11 @@ The following table provides version and version-support information about <%= v
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>2.2.19</td>
+        <td>2.4.x</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>April 30, 2021</td>
+        <td>MMM DD, YYYY</td>
     </tr>
     <tr>
         <td>Software component version</td>
@@ -69,11 +69,11 @@ The following table provides version and version-support information about <%= v
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>2.2.19</td>
+        <td>2.4.x</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>April 30, 2021</td>
+        <td>MMM DD, YYYY</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.ops_manager %> versions</td>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -159,8 +159,8 @@ This diagram illustrates how virus definitions propagate to BOSH VMs with <%= va
 [//]: https://docs.google.com/presentation/d/1pBHK0dcE5y7rT4KnacqFDc6LuU8R3HiR9ApuvwY1uzA/edit
 ![Online (non-air-gapped) update process, following path of new virus data.
 External ClamAV database in the cloud serves new virus data to freshclam running
-on Anti-Virus Mirror VM in the TAS for VMs.
-The Anti-Virus Mirror VM in the TAS for VMs deployment runs it through the database verifier,
+on Anti-Virus Mirror VM in the TAS for VMs deployment.
+The Anti-Virus Mirror VM runs it through the database verifier,
 which is also on the Anti-Virus Mirror VM,
 and then using mTLS serves it to go-clam-tls on all BOSH VMs.
 On each BOSH VM that is running Anti-Virus for VMware Tanzu, go-clam-tls notifies clamd that there are new definitions,
@@ -176,8 +176,8 @@ This diagram illustrates how virus definitions propagate to BOSH VMs with <%= va
 ![Air-gapped update process, following path of new virus data.
 Operators download virus data from External ClamAV database in the cloud to an online workstation.
 They transfer the virus data to the air-gapped off-line workstation.
-The operators then run BOSH SCP to send the data to freshclam running on Anti-Virus Mirror VM in the TAS for VMs.
-The Anti-Virus Mirror VM in the TAS for VMs deployment runs it through the database verifier,
+The operators then run BOSH SCP to send the data to freshclam running on Anti-Virus Mirror VM in the TAS for VMs deployment.
+The Anti-Virus Mirror VM runs it through the database verifier,
 which is also on the Anti-Virus Mirror VM,
 and then using mTLS serves it to go-clam-tls on all BOSH VMs.
 On each BOSH VM that is running Anti-Virus for VMware Tanzu, go-clam-tls notifies clamd that there are new definitions,

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,124 +8,19 @@ This topic contains release notes for <%= vars.product_full %>.
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
-## <a id="2-3-2"></a> v2.3.2
+## <a id="2-4-x"></a> v2.4.x
 
-**Release Date: July 13, 2021**
-
-### Maintenance Changes
-
-Changes in this release:
-
-* **Clamav release:** Updated to v0.103.3
-* On access scanning now run as a separate process: `clamonacc`
-
-### Known issues
-
-There are no known issues for this release.
-
-## <a id="2-2-19"></a> v2.2.19
-
-**Release Date: April 30, 2021**
+**Release Date: MMM DD, YYYY**
 
 ### Maintenance Changes
 
 Changes in this release:
 
-* **Clamav release:** Updated to v0.101.5
-
-### Resolved Issues
-
-This release has the following fix:
-
-* **Fixes package collision issue present in v2.2.13:**
-You no longer receive an error when upgrading <%= vars.product_full %> and
-<%= vars.product_short_mirror %> tiles separately.
+* **Run-in header:** Description
 
 ### Known issues
 
 There are no known issues for this release.
-
-## <a id="2-2-13"></a> v2.2.13
-
-**Release Date: January 21, 2021**
-
-### Features
-
-New features and changes in this release:
-
-* Updates golang dependency to v1.15 for both Linux and Windows.
-* Default VM size for Antivirus Mirror set to 2&nbsp;CPU and 2&nbsp;GB RAM to avoid startup error caused by resource conflict.
-
-### Known Issues
-
-This release has the following issue:
-
-* **When upgrading to v2.2.13 from v2.2.8 or v2.2.2, you must upgrade both tiles at the same time:**
-
-    If you do not upgrade the <%= vars.product_full %> and <%= vars.product_short_mirror %> tiles together,
-    an error about a package collision issue appears:
-
-    <pre class="terminal">...
-Preparing deployment: Preparing deployment (00:00:01)
-                    L Error: Package name collision detected in instance group 'antivirus-mirror': job 'antivirus-mirror/antivirus-mirror' depends on package 'antivirus-mirror/pcre2-10.22' with fingerprint '593d09a37c106fb3bcc359ca2aef7df4906beb843309f0b7c98bb76f2095fe1e', job 'antivirus/antivirus' depends on package 'antivirus/pcre2-10.22' with fingerprint 'c7ea8c775582572ae25c42801962399c02609b3a7024451c236b4b202f87f519'. BOSH cannot currently collocate two packages with identical names and different fingerprints or dependencies.
-Task 6108 | 15:01:35 | Error: Package name collision detected in instance group 'antivirus-mirror': job 'antivirus-mirror/antivirus-mirror' depends on package 'antivirus-mirror/pcre2-10.22' with fingerprint '593d09a37c106fb3bcc359ca2aef7df4906beb843309f0b7c98bb76f2095fe1e', job 'antivirus/antivirus' depends on package 'antivirus/pcre2-10.22' with fingerprint 'c7ea8c775582572ae25c42801962399c02609b3a7024451c236b4b202f87f519'. BOSH cannot currently collocate two packages with identical names and different fingerprints or dependencies.
-</pre>
-
-## <a id="2-2-8"></a> v2.2.8
-
-**Release Date: June 19, 2020**
-
-### Resolved Issues
-
-This release has the following fix:
-
-* <%= vars.product_short %> no longer performs a `chmod` on the `/var/vcap/data/tmp` directory during
-pre-start.
-
-
-### Known Issues
-
-This release has the following issues:
-
-<%= partial vars.path_to_partials + "/antivirus/bbr-ki" %>
-
-
-## <a id="2-2-2"></a> v2.2.2
-
-**Release Date: January 6, 2020**
-
-### Features
-
-New features and changes in this release:
-
-* **CPU limit** for <%= vars.product_short %> is now configured independently of the
-**Enforce CPU limit** field.
-When you upgrade to v2.2 from v2.1, the value of **CPU limit** is reset to the installation default
-of 50%.<br>
-For instructions on setting the **CPU limit**, see [Configure Anti-Virus](./install.html#configure).
-
-* **Timeout to connect to the database server (in seconds)** is now configurable. This field sets
-the timeout for downloading virus definitions from the mirror server.
-For instructions on setting the **Timeout to connect to the database server (in seconds)**, see
-[Configure Anti-Virus](./install.html#configure).
-
-
-### Resolved Issues
-
-This release has the following fix:
-
-* <%= vars.product_short_mirror %> no longer outputs a TLS handshake error log when the process is
-not failing.
-
-
-### Known Issues
-
-This release has the following issues:
-
-<%= partial vars.path_to_partials + "/antivirus/bbr-ki" %>
-
-* <%= vars.product_short %> pre-start can fail when `chmod` is done to the `/var/vcap/data/tmp`
-directory.
 
 
 ## <a id="view"></a> View Release Notes for Another Version

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -44,6 +44,7 @@ See the table below for the new features to consider and the upgrade instruction
           For more information, see <a href="#use-existing">Using an Existing Mirror</a> below.</li>
         <li>If required, configure the mirror port.
           For more information see <a href="#configure-mirror">Configuring the Mirror Port</a> below.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
         <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
         <li>You can set <strong>Timeout to connect to the database server (in seconds)</strong>.</li>
       </ul>
@@ -55,6 +56,7 @@ See the table below for the new features to consider and the upgrade instruction
     <td>
       <ul>
         <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
         <li>You can set <strong>Timeout to connect to the database server (in seconds)</strong>.</li>
       </ul>
       For upgrade instructions, see <a href="#upgrade-v21-v22">Upgrade <%= vars.product_full %> to This Version from v2.1 or Later</a> below.
@@ -65,6 +67,8 @@ See the table below for the new features to consider and the upgrade instruction
     <td>
       <ul>
         <li>It is important the minimum resource requirements are met. Please ensure all VMs where Antivirus will be installed have at least 2GB free RAM and 2 CPU. On Google Cloud Platform (GCP), the recommended minimum VM size is `micro.cpu`</li>
+        <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
       </ul>
       For upgrade instructions, see <a href="#upgrade-v21-v22">Upgrade <%= vars.product_full %> to This Version from v2.1 or Later</a> below.
     </td>


### PR DESCRIPTION
Hi Docs! 

Please can this be merged to 2.3? We have increased the visibility of the warning to ensure that customers configure the tile to have enough memory. 

I also noticed the Upgrade from 2.2 section is not live on the 2.3 docs, so I believe this PR will bring that in as well. 

Please let me know if there are any issues, 

Many thanks

James
