### PR TITLE
Make clear latest tile requires more memory

### DIFF
--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -44,6 +44,7 @@ See the table below for the new features to consider and the upgrade instruction
           For more information, see <a href="#use-existing">Using an Existing Mirror</a> below.</li>
         <li>If required, configure the mirror port.
           For more information see <a href="#configure-mirror">Configuring the Mirror Port</a> below.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
         <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
         <li>You can set <strong>Timeout to connect to the database server (in seconds)</strong>.</li>
       </ul>
@@ -55,7 +56,19 @@ See the table below for the new features to consider and the upgrade instruction
     <td>
       <ul>
         <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
         <li>You can set <strong>Timeout to connect to the database server (in seconds)</strong>.</li>
+      </ul>
+      For upgrade instructions, see <a href="#upgrade-v21-v22">Upgrade <%= vars.product_full %> to This Version from v2.1 or Later</a> below.
+    </td>
+  </tr>
+  <tr>
+    <td>v2.2</td>
+    <td>
+      <ul>
+        <li>It is important the minimum resource requirements are met. Please ensure all VMs where Antivirus will be installed have at least 2GB free RAM and 2 CPU. On Google Cloud Platform (GCP), the recommended minimum VM size is `micro.cpu`</li>
+        <li>VMware recommends that you reset the value of <strong>CPU limit (Percentage)</strong>.</li>
+        <li>The <strong>memory limit</strong> must be raised to at least `1610612736`.</li>
       </ul>
       For upgrade instructions, see <a href="#upgrade-v21-v22">Upgrade <%= vars.product_full %> to This Version from v2.1 or Later</a> below.
     </td>


### PR DESCRIPTION
Hi Docs, 

Sorry for causing a little mess - accidentally pushed directly to the 2.3 branch, so reverted that change and have now created this branch! 

Please merge to 2.3 - this change highlights the requirement to increase the memory when upgrading to the new default memory value. 
This change has been made after a customer incident. 

Please let me know if there are any issues, sorry again for the little Git mess I created!

Many thanks

James

[#179292921]


