### PR TITLE
2.3.10 release notes

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -10,7 +10,7 @@ This topic contains release notes for <%= vars.product_full %>.
 
 ## <a id="2-3-10"></a> v2.3.10
 
-**Release Date: ###**
+**Release Date: September 13, 2021**
 
 <p class="note">
   <strong>Note: </strong>BOSH deployment fails if the minimum recommended VM size is not met.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,6 +8,28 @@ This topic contains release notes for <%= vars.product_full %>.
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
+## <a id="2-3-10"></a> v2.3.10
+
+**Release Date: ###**
+
+<p class="note">
+  <strong>Note: </strong>BOSH deployment fails if the minimum recommended VM size is not met.
+  Ensure all VMs where <%= vars.product_short %> is installed have at least 2&nbsp;GB free RAM and 2&nbsp;CPU.
+  On Google Cloud Platform (GCP), the recommended minimum VM size is <code>micro.cpu</code> using 2&nbsp;CPU and 2&nbsp;GB RAM.
+</p>
+
+### Features
+Changes in this release:
+
+* **Pcre2 release:** Updated to v10.37
+* **Golang release** Updated to v1.16.7
+
+### Known issues
+
+This release has the following issues:
+
+<%= partial vars.path_to_partials + "/antivirus/bbr-ki" %>
+
 ## <a id="2-3-2"></a> v2.3.2
 
 **Release Date: July 15, 2021**


### PR DESCRIPTION
Hi Docs! ⭐️

**Release Date** 13/11/21

We've had our OSL through for the new AV tile. I have put the release date of 13/11/21 in this PR, although we're actually ready to go earlier than this if you come to this ticket before then. 

If you can let us know when this is merged / live we will then release on Pivnet, 

Many thanks

James


CC @kirederik 