### PR TITLE
Add missing new line in log messages

### DIFF
--- a/monitoring-logs.html.md.erb
+++ b/monitoring-logs.html.md.erb
@@ -266,29 +266,29 @@ freshclam log entries relate to whether the virus-signature database is up-to-da
 
 * <a id="freshclam-update"></a>Update the Virus Database
 	<pre class="terminal">
-	Downloading main.cvd [100%]
-	main.cvd updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)
-	Downloading daily.cvd [100%]
-	daily.cvd updated (version: 25135, sigs: 2155329, f-level: 63, builder: neo)
-	Downloading bytecode.cvd [100%]
-	bytecode.cvd updated (version: 327, sigs: 91, f-level: 63, builder: neo)
+	Downloading main.cvd [100%]<br>
+	main.cvd updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)<br>
+	Downloading daily.cvd [100%]<br>
+	daily.cvd updated (version: 25135, sigs: 2155329, f-level: 63, builder: neo)<br>
+	Downloading bytecode.cvd [100%]<br>
+	bytecode.cvd updated (version: 327, sigs: 91, f-level: 63, builder: neo)<br>
 	Database updated (6721669 signatures) from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.169.19)
 	</pre>
 
 * <a id="freshclam-up-to-date"></a>Virus Database Is Up-to-Date
 	<pre class="terminal">
-	main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)
-	daily.cvd is up to date (version: 25135, sigs: 2155329, f-level: 63, builder: neo)
+	main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)<br>
+	daily.cvd is up to date (version: 25135, sigs: 2155329, f-level: 63, builder: neo)<br>
 	bytecode.cvd is up to date (version: 327, sigs: 91, f-level: 63, builder: neo)
   </pre>
 
 * <a id="cld-warnings"></a>Cannot Download CLD Database Files
   <pre class="terminal">
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
-  WARNING: Can't download main.cld from pivotal-anti-virus-mirror.s3.amazonaws.com
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
-  WARNING: Can't download daily.cld from pivotal-anti-virus-mirror.s3.amazonaws.com
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
+  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403<br>
+  WARNING: Can't download main.cld from pivotal-anti-virus-mirror.s3.amazonaws.com<br>
+  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403<br>
+  WARNING: Can't download daily.cld from pivotal-anti-virus-mirror.s3.amazonaws.com<br>
+  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403<br>
   WARNING: Can't download bytecode.cld from pivotal-anti-virus-mirror.s3.amazonaws.com</pre>
 
 * <a id="freshclam-old"></a>Virus Database is Older Than 7 Days
@@ -317,39 +317,37 @@ go-clam-tls log entries relate to whether the virus-signature database is up-to-
 
 * <a id="go-clam-tls-update"></a>Update the Virus Database
 	<pre class="terminal">
-	2019/10/03 20:40:15 go-clam-tls update process started
-  2019/10/03 20:40:15 Warning: could not parse local main.cvd header: open /var/vcap/data/antivirus/main.cvd: no such file or directory
-  2019/10/03 20:40:26 main.cvd updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)
-  2019/10/03 20:40:26 Warning: could not parse local daily.cvd header: open /var/vcap/data/antivirus/daily.cvd: no such file or directory
-  2019/10/03 20:40:31 daily.cvd updated (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)
-  2019/10/03 20:40:31 Warning: could not parse local bytecode.cvd header: open /var/vcap/data/antivirus/bytecode.cvd: no such file or directory
-  2019/10/03 20:40:31 bytecode.cvd updated (version: 331, sigs: 94, f-level: 63, builder: anvilleg, build timestamp: 19 Sep 2019 12-12 -0400)
-  2019/10/03 20:40:31 Clamd socket response: RELOADING
-  <br>
+	2019/10/03 20:40:15 go-clam-tls update process started<br>
+  2019/10/03 20:40:15 Warning: could not parse local main.cvd header: open /var/vcap/data/antivirus/main.cvd: no such file or directory<br>
+  2019/10/03 20:40:26 main.cvd updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)<br>
+  2019/10/03 20:40:26 Warning: could not parse local daily.cvd header: open /var/vcap/data/antivirus/daily.cvd: no such file or directory<br>
+  2019/10/03 20:40:31 daily.cvd updated (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)<br>
+  2019/10/03 20:40:31 Warning: could not parse local bytecode.cvd header: open /var/vcap/data/antivirus/bytecode.cvd: no such file or directory<br>
+  2019/10/03 20:40:31 bytecode.cvd updated (version: 331, sigs: 94, f-level: 63, builder: anvilleg, build timestamp: 19 Sep 2019 12-12 -0400)<br>
+  2019/10/03 20:40:31 Clamd socket response: RELOADING<br>
   2019/10/03 20:40:31 Databases successfully updated
   </pre>
 
 * <a id="go-clam-tls-using-cld"></a>Using CLD Database Files
   <pre class="terminal">
-  2019/10/03 20:42:31 go-clam-tls update process started
-  2019/10/03 20:42:31 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for main.cvd, trying main.cld...
-  2019/10/03 20:42:31 Warning: could not parse local main.cld header: open /var/vcap/data/antivirus/main.cld: no such file or directory
-  2019/10/03 20:42:38 main.cld updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)
-  2019/10/03 20:42:38 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for daily.cvd, trying daily.cld...
-  2019/10/03 20:42:38 Warning: could not parse local daily.cld header: open /var/vcap/data/antivirus/daily.cld: no such file or directory
-  2019/10/03 20:42:38 daily.cld updated (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)
-  2019/10/03 20:42:38 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for bytecode.cvd, trying bytecode.cld...
-  2019/10/03 20:42:38 Warning: could not parse local bytecode.cld header: open /var/vcap/data/antivirus/bytecode.cld: no such file or directory
-  2019/10/03 20:42:38 bytecode.cld updated (version: 331, sigs: 94, f-level: 63, builder: anvilleg, build timestamp: 19 Sep 2019 12-12 -0400)
-  2019/10/03 20:42:38 Clamd socket response: RELOADING
-  <br>
+  2019/10/03 20:42:31 go-clam-tls update process started<br>
+  2019/10/03 20:42:31 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for main.cvd, trying main.cld...<br><br>
+  2019/10/03 20:42:31 Warning: could not parse local main.cld header: open /var/vcap/data/antivirus/main.cld: no such file or directory<br>
+  2019/10/03 20:42:38 main.cld updated (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)<br>
+  2019/10/03 20:42:38 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for daily.cvd, trying daily.cld...<br>
+  2019/10/03 20:42:38 Warning: could not parse local daily.cld header: open /var/vcap/data/antivirus/daily.cld: no such file or directory<br>
+  2019/10/03 20:42:38 daily.cld updated (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)<br>
+  2019/10/03 20:42:38 Anti-Virus Mirror antivirus-mirror.service.internal:6501 returned 404 for bytecode.cvd, trying bytecode.cld...<br>
+  2019/10/03 20:42:38 Warning: could not parse local bytecode.cld header: open /var/vcap/data/antivirus/bytecode.cld: no such file or directory<br>
+  2019/10/03 20:42:38 bytecode.cld updated (version: 331, sigs: 94, f-level: 63, builder: anvilleg, build timestamp: 19 Sep 2019 12-12 -0400)<br>
+  2019/10/03 20:42:38 Clamd socket response: RELOADING<br>
   2019/10/03 20:42:38 Databases successfully updated
   </pre>
 
 * <a id="go-clam-tls-up-to-date"></a>Virus Database Is Up-to-Date
 	<pre class="terminal">
-	2019/10/03 20:30:21 main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)
-  2019/10/03 20:30:21 daily.cvd is up to date (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)
+	2019/10/03 20:30:21 main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr, build timestamp: 07 Jun 2017 17-38 -0400)<br>
+  2019/10/03 20:30:21 daily.cvd is up to date (version: 25591, sigs: 1793277, f-level: 63, builder: raynman, build timestamp: 03 Oct 2019 04-30 -0400)<br>
   2019/10/03 20:30:21 bytecode.cvd is up to date (version: 331, sigs: 94, f-level: 63, builder: anvilleg, build timestamp: 19 Sep 2019 12-12 -0400)
   </pre>
 


### PR DESCRIPTION
Some log messages are being displayed in 1 single line but that's not what customers see in the log files.

Adding new lines between log messages.

I do not have the tools installed locally to double check visually my changes. It would be great if you could double check on your side plz.