### PR TITLE
Update new recommended memory default

### DIFF
--- a/install.html.md.erb
+++ b/install.html.md.erb
@@ -22,9 +22,9 @@ Manager documentation.
 * **<%= vars.ops_manager_full %> (Ops Manager)**.
 For compatible versions, see the [Product Snapshot](./index.html#snapshot).
 
-* **At least 2&nbsp;GB of RAM free for each VM that installs <%= vars.product_short %>**.
-  <%= vars.product_short %> installs itself on each tile VM and runs internally. <%= vars.product_short %> takes at least 1.3&nbsp;GB of RAM on each VM.
-  On Google Cloud Platform (GCP), the recommended minimum VM size is `micro.cpu` using 2&nbsp;CPU and 2&nbsp;GB RAM.
+* **At least 4&nbsp;GB of RAM free for each VM that installs <%= vars.product_short %>**.
+  <%= vars.product_short %> installs itself on each tile VM and runs internally. <%= vars.product_short %> takes at least 3&nbsp;GB of RAM on each VM, reserving
+  On Google Cloud Platform (GCP), the recommended minimum VM size is `micro.cpu` using 2&nbsp;CPU and 4&nbsp;GB RAM.
 
 * **An external mirror**. If you do not have an external mirror, VMware recommends that you install
   the <%= vars.product_short_mirror %>.
@@ -178,7 +178,7 @@ upcHi9nzBhDFKdT3uhaQqNBU4UtJx5g=
         <td><strong>Memory limit (in bytes)</strong></td>
         <td>
           Enter the maximum amount of user memory (including file cache) in bytes that <%= vars.product_short %> can use.
-          The default value is <code>1610612736</code>, which is the recommended minimum value.
+          The default value is <code>4294967296</code>, which is the recommended minimum value.
         </td>
       </tr>
       <tr>

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -115,6 +115,30 @@ If the internal <%= vars.product_short_mirror %> has the latest files, no action
 
 ## <a id="runtime"></a> Runtime Issues
 
+### <a id="malware-detection"></a> <%= vars.product_short %> Restarting everyday
+
+#### Symptom
+
+Observed in logs...
+
+#### Explanation
+
+<a id="malware-detection"></a> <%= vars.product_short %> updates its virus database twice a day. To ensure no downtime there needs to be enough memory allocated to hold the old and new databases in memory for a short period. If there is insufficient memory a restart is needed.
+
+The minimum recommended memory required by <a id="malware-detection"></a> <%= vars.product_short %> may have changed since the product was installed.
+
+#### Solution
+
+Ensure that the tile config reserves a minimum of 3Gb of memory for AV (4GB preferred).
+
+Memory limit (in bytes)
+
+#### Solution
+
+Set the **Memory limit (in bytes)** to a minimum value of **3221225472** in the Anti-Virus tile. For instructions, see Configure Anti-Virus.
+
+
+
 ### <a id="malware-detection"></a> <%= vars.product_short %> Is Not Detecting Malware
 
 #### Symptom


### PR DESCRIPTION
The minimum required memory allocated to AV has been changed from 1.5Gb to 3Gb.
The recommended memory allocated has been changed to 4GB - this is what the default tile config will show.