### PR TITLE
rename example mirror

### DIFF
--- a/changing-ports-existing.html.md.erb
+++ b/changing-ports-existing.html.md.erb
@@ -78,7 +78,7 @@ Use the **Existing Mirror** or **Existing Mirror with TLS** information below.
             <td>
             <strong>Mirror hostname without leading https://</strong></td>
             <td>Enter the hostname or IP address of your existing mirror.<br>
-              For example, <code>pivotal-anti-virus-mirror.s3.amazonaws.com</code> or
+              For example, <code>my-anti-virus-mirror.s3.example.com</code> or
               <code>10.0.4.5</code>.
               <strong>Note: </strong> Ensure that your existing mirror server uses the correct
               certificate for the hostname or IP address.

--- a/install.html.md.erb
+++ b/install.html.md.erb
@@ -196,7 +196,7 @@ To configure <%= vars.product_short %>:
       <tr>
         <td><strong>Mirror hostname without leading https://</strong></td>
         <td>Enter the hostname or IP address for your existing mirror.<br>
-          For example: <code>pivotal-anti-virus-mirror.s3.amazonaws.com</code> or
+          For example: <code>my-anti-virus-mirror.s3.example.com</code> or
           <code>10.0.4.5</code>
           <strong>Note:</strong> Ensure that your existing mirror server is using the correct
           certificate for the hostname or IP address.

--- a/monitoring-logs.html.md.erb
+++ b/monitoring-logs.html.md.erb
@@ -272,7 +272,7 @@ freshclam log entries relate to whether the virus-signature database is up-to-da
 	daily.cvd updated (version: 25135, sigs: 2155329, f-level: 63, builder: neo)
 	Downloading bytecode.cvd [100%]
 	bytecode.cvd updated (version: 327, sigs: 91, f-level: 63, builder: neo)
-	Database updated (6721669 signatures) from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.169.19)
+	Database updated (6721669 signatures) from my-anti-virus-mirror.s3.example.com (IP: 52.216.169.19)
 	</pre>
 
 * <a id="freshclam-up-to-date"></a>Virus Database Is Up-to-Date
@@ -284,12 +284,12 @@ freshclam log entries relate to whether the virus-signature database is up-to-da
 
 * <a id="cld-warnings"></a>Cannot Download CLD Database Files
   <pre class="terminal">
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
-  WARNING: Can't download main.cld from pivotal-anti-virus-mirror.s3.amazonaws.com
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
-  WARNING: Can't download daily.cld from pivotal-anti-virus-mirror.s3.amazonaws.com
-  WARNING: getfile: Unknown response from pivotal-anti-virus-mirror.s3.amazonaws.com (IP: 52.216.233.147): HTTP/1.1 403
-  WARNING: Can't download bytecode.cld from pivotal-anti-virus-mirror.s3.amazonaws.com</pre>
+  WARNING: getfile: Unknown response from my-anti-virus-mirror.s3.example.com (IP: 52.216.233.127): HTTP/1.1 403
+  WARNING: Can't download main.cld from my-anti-virus-mirror.s3.example.com
+  WARNING: getfile: Unknown response from my-anti-virus-mirror.s3.example.com (IP: 52.216.233.127): HTTP/1.1 403
+  WARNING: Can't download daily.cld from my-anti-virus-mirror.s3.example.com
+  WARNING: getfile: Unknown response from my-anti-virus-mirror.s3.example.com (IP: 52.216.233.127): HTTP/1.1 403
+  WARNING: Can't download bytecode.cld from my-anti-virus-mirror.s3.example.com</pre>
 
 * <a id="freshclam-old"></a>Virus Database is Older Than 7 Days
 	<pre class="terminal">


### PR DESCRIPTION
We have become aware that some folks have been using "pivotal-anti-virus-mirror.s3.amazonaws.com" which is meant only to be an example. We have therefore renamed the example to something which does not work.