### PR TITLE
Added Jammy support

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -51,7 +51,7 @@ The following table provides version and version-support information about <%= v
     </tr>
     <tr>
         <td>Compatible BOSH stemcells</td>
-        <td>Ubuntu Xenial and Windows (2019, 1803, and 2016)</td>
+        <td>Ubuntu Jammy, Ubuntu Xenial and Windows (2019, 1803, and 2016)</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -88,7 +88,7 @@ The following table provides version and version-support information about <%= v
     </tr>
     <tr>
         <td>Compatible BOSH stemcells</td>
-        <td>Ubuntu Xenial and Windows (2019, 1803, and 2016)</td>
+        <td>Ubuntu Jammy and Windows (2019, 1803, and 2016)</td>
     </tr>
     <tr>
         <td>IaaS support</td>


### PR DESCRIPTION
Added Jammy support. We forgot to update the docs to indicate, AV supports Jammy and the Mirror supports Jammy, but not Xenial.