### PR TITLE
Describe the clamonacc issue

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -36,15 +36,15 @@ The following table provides version and version-support information about <%= v
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>Open Source ClamAV 0.103.8</td>
+        <td>Open Source ClamAV 1.0.3</td>
     </tr>
     <tr>
         <td>Compatible Tanzu Operations Manager versions</td>
-        <td>3.0, 2.10, 2.9, 2.8, and 2.7</td>
+        <td>3.0 and 2.10</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) versions</td>
-        <td>4.0, 3.0, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, and 2.7</td>
+        <td>5.0, 4.0, 2.13 and 2.11</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.k8s_runtime_full %> (<%= vars.k8s_runtime_abbr %>) versions</td>
@@ -71,19 +71,19 @@ The following table provides version and version-support information about <%= v
     </tr></thead>
     <tr>
         <td>Version</td>
-        <td>2.3.37</td>
+        <td>2.3.60</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 2, 2023</td>
+        <td>January 10, 2024</td>
     </tr>
     <tr>
         <td>Compatible Tanzu Operations Manager versions</td>
-        <td>3.0, 2.10, 2.9, 2.8, and 2.7</td>
+        <td>3.0 and 2.10</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) versions</td>
-        <td>4.0, 3.0, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, and 2.7</td>
+        <td>5.0, 4.0, 2.13 and 2.11</td>
     </tr>
     <tr>
         <td>Compatible <%= vars.k8s_runtime_full %> (<%= vars.k8s_runtime_abbr %>) versions</td>
@@ -110,6 +110,13 @@ The following table provides version and version-support information about <%= v
   * Supports scheduled scans to reduce workload during peak operation hours.
   * Permits adding known signatures to an allowlist.
   * Allows you to configure CPU and memory usage limits on VMs of the foundation.
+
+## <a id="known-issues"></a> Known Issues
+
+On-access scanning on Linux may cause performance degradation. For the moment,
+the workaround is to enable the VM Resurrector Plugin in the BOSH tile.
+See <a href="./troubleshooting.html#on-access-scan-degradation">troubleshooting</a>
+for more details.
 
 ## <a id="architecture"></a> <%= vars.product_short %> Architecture
 

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -367,7 +367,7 @@ This causes <%= vars.product_short %> to ignore the **Enforce CPU limit** settin
 Increase the VM size. VMware recommends a minimum VM size of `micro.cpu` using 2&nbsp;CPU and
 2&nbsp;GB RAM.
 
-### <a id='query-ping-fail'></a> Freshclam logs show "can't query *.ping.clamav.net"
+### <a id="query-ping-fail"></a> Freshclam logs show "can't query *.ping.clamav.net"
 
 #### Symptom
 
@@ -390,3 +390,24 @@ difficulty, but this is unrelated to downloading virus definitions and does not 
 #### Solution
 
 No action is required. This issue does not impact the functionality of <%= vars.product_short %>.
+
+### <a id="on-access-scan-degradation"</a> VM status becomes `failing` or `unresponsive agent` for
+unrelated Ubuntu VMs
+
+#### Symptom
+
+When On-Access Scan is enabled, status for VMs running on Ubuntu stemcells becomes `unresponsive agent`
+or `failing`, especially on unrelated VMs across different deployments, and the behavior disappears when
+On-Access Scan is disabled.
+
+#### Explanation
+
+A few issues were uncovered in ClamAV On-Access Scanner causing infinite loops under varying circumstances.
+As a result, the On-Access Scanner will have a large number of files opened, causing resource starvation
+on the VM, causing the failures.
+
+#### Solution
+
+The described issue is fixed in ClamAV 1.3.0. Upgrade to the <%= vars.product_short %> to a version containing
+ClamAV 1.3.0 or later, once it becomes available. Until then, the possible workarounds are either to enable
+the "VM Resurrector Plugin" in the BOSH tile, or disable the On-Access Scanner.


### PR DESCRIPTION
ClamAV 1.0.x until 1.3.0 (about to be released) supplies a clamonacc binary that may cause performance issues on VMs.
Additionally, some clarifications made in relation to shipped software and supported platforms for both the anti-virus and the anti-virus mirror tiles.